### PR TITLE
Add queue worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/grpc-kit.
+Bug reports and pull requests are welcome on GitHub at https://github.com/b2beauty/grpc-kit.
 
 
 ## License

--- a/exe/grpc-kit
+++ b/exe/grpc-kit
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+
+require 'bundler/setup'
+require 'grpc/kit'
+
+GRPC::Kit::Cli.start(ARGV)

--- a/grpc-kit.gemspec
+++ b/grpc-kit.gemspec
@@ -22,8 +22,9 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'google-cloud-pubsub', '~> 0.22.0'
+  spec.add_dependency 'thor',                '~> 0.19.4'
 
   spec.add_development_dependency 'bundler', '~> 1.14'
-  spec.add_development_dependency 'rake',    '~> 10.0'
+  spec.add_development_dependency 'rake',    '~> 12.0'
   spec.add_development_dependency 'rspec',   '~> 3.0'
 end

--- a/lib/grpc/kit.rb
+++ b/lib/grpc/kit.rb
@@ -1,3 +1,4 @@
+require 'grpc/kit/cli'
 require 'grpc/kit/communication'
 require 'grpc/kit/logger'
 require 'grpc/kit/queue'

--- a/lib/grpc/kit/cli.rb
+++ b/lib/grpc/kit/cli.rb
@@ -1,0 +1,38 @@
+require 'thor'
+
+workers_dir = File.join(Dir.pwd, 'lib', 'workers')
+$LOAD_PATH.unshift(workers_dir) unless $LOAD_PATH.include?(workers_dir)
+
+module GRPC
+  module Kit
+    class Workers < Thor
+      desc 'runner <worker> <topic>', 'Run <worker> for <topic>'
+      def runner(worker, topic)
+        require worker.gsub(/(.)([A-Z])/,'\1_\2').downcase
+
+        Queue::Worker::Runner.run! topic: topic, worker: worker
+      end
+
+      desc 'list', 'List available workers'
+      def list
+        Dir.glob('lib/workers/**/*') do |file|
+          require File.basename(file, File.extname(file))
+        end
+
+        workers = GRPC::Kit::Queue::Worker.list
+        if workers.empty?
+          puts 'No available workers'
+        else
+          workers.each do |worker|
+            puts " - #{worker}"
+          end
+        end
+      end
+    end
+
+    class Cli < Thor
+      desc 'workers SUBCOMMAND ...ARGS', 'run or manage workers'
+      subcommand 'workers', Workers
+    end
+  end
+end

--- a/lib/grpc/kit/queue.rb
+++ b/lib/grpc/kit/queue.rb
@@ -1,1 +1,2 @@
 require_relative 'queue/publisher'
+require_relative 'queue/worker'

--- a/lib/grpc/kit/queue/worker.rb
+++ b/lib/grpc/kit/queue/worker.rb
@@ -9,6 +9,10 @@ module GRPC
           @@workers << klass
         end
 
+        def self.list
+          @@workers rescue []
+        end
+
         def call
           raise NotImplemented.new
         end

--- a/lib/grpc/kit/queue/worker.rb
+++ b/lib/grpc/kit/queue/worker.rb
@@ -10,7 +10,9 @@ module GRPC
         end
 
         def self.list
-          @@workers rescue []
+          @@workers
+        rescue NameError
+          []
         end
 
         def call

--- a/lib/grpc/kit/queue/worker.rb
+++ b/lib/grpc/kit/queue/worker.rb
@@ -1,0 +1,18 @@
+require_relative 'worker/runner'
+
+module GRPC
+  module Kit
+    module Queue
+      module Worker
+        def self.included(klass)
+          @@workers ||= []
+          @@workers << klass
+        end
+
+        def call
+          raise NotImplemented.new
+        end
+      end
+    end
+  end
+end

--- a/lib/grpc/kit/queue/worker/runner.rb
+++ b/lib/grpc/kit/queue/worker/runner.rb
@@ -27,7 +27,9 @@ module GRPC
           private
 
           def worker
-            Object.const_get(@worker_class) rescue nil
+            Object.const_get(@worker_class)
+          rescue NameError
+            nil
           end
 
           def subscription

--- a/lib/grpc/kit/queue/worker/runner.rb
+++ b/lib/grpc/kit/queue/worker/runner.rb
@@ -1,0 +1,48 @@
+module GRPC
+  module Kit
+    module Queue
+      module Worker
+        class Runner
+          def initialize(params)
+            @topic_name        = params[:topic]
+            @subscription_name = "#{params[:topic]}.#{params[:worker]}"
+            @worker_class      = params[:worker]
+          end
+
+          def self.run!(params)
+            new(params).run!
+          end
+
+          def run!
+            if worker.nil?
+              GRPC.logger.error("class #{worker} does not exist")
+              exit
+            end
+
+            subscription.listen do |msg|
+              worker.new(msg).call
+            end
+          end
+
+          private
+
+          def worker
+            Object.const_get(@worker_class) rescue nil
+          end
+
+          def subscription
+            @subscription ||= topic.subscription(@subscription_name) || topic.subscribe(@subscription_name)
+          end
+
+          def topic
+            @topic ||= pubsub.topic(@topic_name) || pubsub.create_topic(@topic_name)
+          end
+
+          def pubsub
+            @pubsub ||= Google::Cloud::Pubsub.new
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/grpc/kit/queue/worker/runner.rb
+++ b/lib/grpc/kit/queue/worker/runner.rb
@@ -15,7 +15,7 @@ module GRPC
 
           def run!
             if worker.nil?
-              GRPC.logger.error("class #{worker} does not exist")
+              GRPC.logger.error("class #{@worker_class} does not exist")
               exit
             end
 

--- a/spec/grpc/kit/queue/worker/runner_spec.rb
+++ b/spec/grpc/kit/queue/worker/runner_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+
+RSpec.describe GRPC::Kit::Queue::Worker::Runner do
+  let(:pubsub)       { double(:pubsub, topic: topic) }
+  let(:topic)        { double(:topic, subscription: subscription) }
+  let(:subscription) { double(:subscription, listen: true) }
+  let(:params)       { { topic: topic_name, worker: worker_class } }
+  let(:topic_name)   { 'topic_name' }
+  let(:worker_class) { 'Class' }
+
+  subject { described_class.new(params) }
+
+  before do
+    subject.instance_variable_set :@pubsub, pubsub
+  end
+
+  it '.run!' do
+    expect(described_class)
+      .to receive(:new)
+            .with(params)
+            .and_return(double(:runner, run!: true))
+
+    described_class.run! params
+  end
+
+  describe '#run!' do
+    context 'when does not exist worker_class' do
+      let(:worker_class) { 'OhBlaDih' }
+
+      it 'receives exit' do
+        expect(subject).to receive(:exit)
+
+        subject.run!
+      end
+    end
+
+    it 'when does not exist topic creates a new' do
+      allow(pubsub).to receive(:topic).and_return(nil)
+      expect(pubsub).to receive(:create_topic).with(topic_name).and_return(topic)
+
+      subject.run!
+    end
+
+    it 'when exists topic use existent' do
+      expect(pubsub).to_not receive(:create_topic)
+
+      subject.run!
+    end
+
+    it 'when does not exist subscription creates a new' do
+      allow(topic).to receive(:subscription).and_return(nil)
+      expect(topic).to receive(:subscribe).with("#{topic_name}.#{worker_class}").and_return(subscription)
+
+      subject.run!
+    end
+
+    it 'when exists subscription use existent' do
+      expect(topic).to_not receive(:subscribe)
+
+      subject.run!
+    end
+  end
+end

--- a/spec/grpc/kit/queue/worker_spec.rb
+++ b/spec/grpc/kit/queue/worker_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+RSpec.describe GRPC::Kit::Queue::Worker do
+  describe '.list' do
+    it 'without workers' do
+      expect(described_class.list).to eq []
+    end
+
+    it 'with workers' do
+      object = Class.new
+      object.include described_class
+
+      expect(described_class.list).to include object.class
+    end
+  end
+end


### PR DESCRIPTION
Resolves #6

- [x] Structure to workers
- [x] Runner
- [x] Cli for runner
- [x] Specs

## Exemplo de implementação de worker

```ruby
# Worker que ficará dentro dos microserviços:
# lib/workers/my_worker.rb
class MyWorker
  include GRPC::Kit::Queue::Worker

  def initialize(msg)
    @msg = msg
    @msg.ack! # o `acknowledgment` fica por conta da implementação (;
  end

  def call
    puts @msg.to_json
  end
end
```

## Exemplo de listagem de workers

```bash
$ grpc-kit workers list
 - MyWorker
```

## Exemplo de _run_ de worker

```bash
$ grpc-kit workers runner MyWorker topic
D, [2017-02-17T00:31:05.120736 #1355] DEBUG -- : calling pubsub:8042:443:/google.pubsub.v1.Publisher/GetTopic
D, [2017-02-17T00:31:05.136040 #1355] DEBUG -- : calling pubsub:8042:443:/google.pubsub.v1.Subscriber/GetSubscription
D, [2017-02-17T00:31:05.156333 #1355] DEBUG -- : calling pubsub:8042:443:/google.pubsub.v1.Subscriber/Pull
```