### PR TITLE
Documentation for 0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,33 @@ GRPC::Kit::Queue::Publisher.publish('topic_name', 'message')
 
 ### GRPC::Kit::Queue::Worker
 
+Create a class in `lib/workers` and including `GRPC::Kit::Queue::Worker`:
+
+```ruby
+# lib/workers/my_worker.rb
+class MyWorker
+  include GRPC::Kit::Queue::Worker
+
+  def initialize(msg)
+    @msg = msg
+  end
+
+  def call
+    puts @msg.data
+    @msg.ack!
+  end
+end
+```
+
+And you can use:
+
+```bash
+# to list available workers
+grpc-kit workers list
+# to run a worker
+grpc-kit workers runner MyWorker topic_name
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/README.md
+++ b/README.md
@@ -18,9 +18,37 @@ Or install it yourself as:
 
     $ gem install grpc-kit
 
-## Usage
+## Documentation
 
-TODO: Write usage instructions here
+- [`GRPC::Kit::Communication::Resilient`](#grpckitcommunicationresilient)
+- [`GRPC::Kit::Logger`](#grpckitlogger)
+- [`GRPC::Kit::Queue::Publisher`](#grpckitqueuepublisher)
+- [`GRPC::Kit::Queue::Worker`](#grpckitqueueworker)
+
+### GRPC::Kit::Communication::Resilient
+
+Sometimes, GRPC and Google::Cloud raises _unavailable error_, but you can retry and all works fine. Based on [Datastore documentation](https://cloud.google.com/appengine/articles/handling_datastore_errors#timeouts-due-to-datastore-issues) we implemented a _helper_ to _resilient communication_.
+
+Example:
+
+```ruby
+pubsub = Google::Cloud::Pubsub.new
+topic  = pubsub.create_topic('topic_name')
+topic.publish('message') # receives Google::Cloud::UnavailableError
+
+# But you can uses resilient communication
+include GRPC::Kit::Communication::Resilient
+topic = resilient { topic.publish('message') }
+
+# And you can sets the limit of repetition...
+topic = resilient(limit: 5) { topic.publish('message') }
+```
+
+### GRPC::Kit::Logger
+
+### GRPC::Kit::Queue::Publisher
+
+### GRPC::Kit::Queue::Worker
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Or install it yourself as:
 
 ### GRPC::Kit::Communication::Resilient
 
-Sometimes, GRPC and Google::Cloud raises _unavailable error_, but you can retry and all works fine. Based on [Datastore documentation](https://cloud.google.com/appengine/articles/handling_datastore_errors#timeouts-due-to-datastore-issues) we implemented a _helper_ to _resilient communication_.
+Sometimes, GRPC and Google::Cloud raises _unavailable error_, but you can retry and all works fine. Based on [Datastore documentation](https://cloud.google.com/appengine/articles/handling_datastore_errors#timeouts-due-to-datastore-issues) we implemented a _helper_ for _resilient communication_.
 
 Example:
 
@@ -46,11 +46,11 @@ topic = resilient(limit: 5) { topic.publish('message') }
 
 ### GRPC::Kit::Logger
 
-By default all logs sent to `GRPC.logger` are ignored. But `GRPC::Kit::Logger` configure automatically logs to use _STDOUT_.
+By default all logs sent to `GRPC.logger` are ignored. But `GRPC::Kit::Logger` automatically configures logs to use _STDOUT_.
 
 ### GRPC::Kit::Queue::Publisher
 
-To publish a message to topic (creating if not exists) you need only configure environment variables for `Google::Cloud::Pubsub` and use:
+To publish a message to topic (creating one if none exists) you only need to configure environment variables for `Google::Cloud::Pubsub` and use:
 
 ```ruby
 GRPC::Kit::Queue::Publisher.publish('topic_name', 'message')
@@ -58,7 +58,7 @@ GRPC::Kit::Queue::Publisher.publish('topic_name', 'message')
 
 ### GRPC::Kit::Queue::Worker
 
-Create a class in `lib/workers` and including `GRPC::Kit::Queue::Worker`:
+Create a class in `lib/workers` including `GRPC::Kit::Queue::Worker`:
 
 ```ruby
 # lib/workers/my_worker.rb

--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ By default all logs sent to `GRPC.logger` are ignored. But `GRPC::Kit::Logger` c
 
 ### GRPC::Kit::Queue::Publisher
 
+To publish a message to topic (creating if not exists) you need only configure environment variables for `Google::Cloud::Pubsub` and use:
+
+```ruby
+GRPC::Kit::Queue::Publisher.publish('topic_name', 'message')
+```
+
 ### GRPC::Kit::Queue::Worker
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ topic = resilient(limit: 5) { topic.publish('message') }
 
 ### GRPC::Kit::Logger
 
+By default all logs sent to `GRPC.logger` are ignored. But `GRPC::Kit::Logger` configure automatically logs to use _STDOUT_.
+
 ### GRPC::Kit::Queue::Publisher
 
 ### GRPC::Kit::Queue::Worker


### PR DESCRIPTION
- [x] `GRPC::Kit::Communication::Resilient`
- [x] `GRPC::Kit::Logger`
- [x] `GRPC::Kit::Queue::Publisher`
- [x] `GRPC::Kit::Queue::Worker`

Resolves #4 
